### PR TITLE
避免在脚本结束，执行到__del__时，端口已经断开导致的报错

### DIFF
--- a/hrpc/client.py
+++ b/hrpc/client.py
@@ -60,11 +60,14 @@ class RpcClient(object):
                 self.transport.add_response_callback(reqid, on_response)
 
             try:
-                self.transport.send({'id': reqid, 'uri': obj_proxy._uri__, 'method': obj_proxy._invocation_path__})
+                self.transport.send({'id': reqid, 'uri': obj_proxy._uri__, 'method': obj_proxy._invocation_path__},
+                                    timeout=None if wait_for_response else 0.3)
             except TransportDisconnected as e:
                 # 如果传输层断开了，则不需要析构该对象了
                 obj_proxy._is_intermediate_uri__ = False
-                raise
+                if wait_for_response:
+                    # 如果wait_for_response为false，则不关心执行结果是否正确
+                    raise
 
             if wait_for_response and not on_response:
                 timedout = not evt.wait(timeout=self._timeout)

--- a/hrpc/object_proxy.py
+++ b/hrpc/object_proxy.py
@@ -87,7 +87,7 @@ class RpcObjectProxy(object):
             self._client__.evaluate(RpcObjectProxy(self._uri__, self._client__, path, self))
         return value
 
-    def __call__(self, *args):
+    def __call__(self, *args, **kwargs):
         remote_obj_cache = []
         return self._client__.evaluate(self.__call_no_evaluate__(remote_obj_cache, *args))
 

--- a/hrpc/transport/__init__.py
+++ b/hrpc/transport/__init__.py
@@ -16,7 +16,7 @@ class Transport(object):
         self._connected = False
         self._response_callbacks = defaultdict(set)
 
-    def send(self, req):
+    def send(self, req, timeout=None):
         raise NotImplementedError
 
     def connect(self):

--- a/hrpc/transport/http.py
+++ b/hrpc/transport/http.py
@@ -17,10 +17,11 @@ class HttpTransport(Transport):
         super(HttpTransport, self).__init__(endpoint, client)
         self.connect()
 
-    def send(self, req):
+    def send(self, req, timeout=None):
         req['session_id'] = self.session_id
         try:
-            r = requests.post(self.endpoint, data=json.dumps(req), headers={'Content-Type': 'application/json'})
+            r = requests.post(self.endpoint, data=json.dumps(req), headers={'Content-Type': 'application/json'},
+                              timeout=timeout)
             self.rpc_client.put_response(r.json())
         except (ConnectionError, ValueError) as e:
             raise TransportDisconnected(e)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def parse_requirements(filename='requirements.txt'):
 
 setup(
     name='hrpc',
-    version='1.0.8',
+    version='1.0.9',
     keywords="hrpc rpc",
     description='A common interface based RPC framework',
     packages=find_packages(),


### PR DESCRIPTION
示例代码：
```
node = poco(text="应用推荐")
print(node.exists())
```
这段代码在脚本运行结束时，可能会因为端口已经被回收，导致无法继续与pocoservice通信，因此在node执行`__del__`时连接会失败，于是会报下面的错误：

```
Exception ignored in: <bound method RpcObjectProxy.__del__ of '<Rpc remote object proxy of [Lcom.netease.open.libpoco.sdk.AbstractNode;@169eba3>'>
Traceback (most recent call last):
  File "d:\project\airtestide\hrpc\hrpc\object_proxy.py", line 118, in __del__
  File "d:\project\airtestide\hrpc\hrpc\client.py", line 63, in evaluate
  File "d:\project\airtestide\hrpc\hrpc\transport\http.py", line 27, in send
hrpc.exceptions.TransportDisconnected: HTTPConnectionPool(host='127.0.0.1', port=11385): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x00000163D9E31C18>: Failed to establish a new connection: [WinError 10061] 由于目标计算机积极拒绝，无法连接。',))
```

目前的修改是增加timeout避免长时间卡住、暂时忽略掉在结束时的报错，但是当脚本中有大量节点被创建时可能会卡住较长时间。